### PR TITLE
JavaComplete_EnableDefaultMappings: fix documentation and logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,63 +98,63 @@ Add this to your `.vimrc` file:
 
 `autocmd FileType java setlocal omnifunc=javacomplete#Complete`
 
-To enable smart (trying to guess import option) inserting class imports with F4, add:
+Inside `~/.vim/after/ftplugin/java.vim` (on Linux and MacOS) respectively ``%USERPROFILE%/vimfiles/after/ftplugin/java.vim`` on Microsoft Windows, to enable smart (trying to guess import option) inserting class imports with F4, add:
 
-`nmap <F4> <Plug>(JavaComplete-Imports-AddSmart)`
+`nmap <buffer> <F4> <Plug>(JavaComplete-Imports-AddSmart)`
 
-`imap <F4> <Plug>(JavaComplete-Imports-AddSmart)`
+`imap <buffer> <F4> <Plug>(JavaComplete-Imports-AddSmart)`
 
 To enable usual (will ask for import option) inserting class imports with F5, add:
 
-`nmap <F5> <Plug>(JavaComplete-Imports-Add)`
+`nmap <buffer> <F5> <Plug>(JavaComplete-Imports-Add)`
 
-`imap <F5> <Plug>(JavaComplete-Imports-Add)`
+`imap <buffer> <F5> <Plug>(JavaComplete-Imports-Add)`
 
 To add all missing imports with F6:
 
-`nmap <F6> <Plug>(JavaComplete-Imports-AddMissing)`
+`nmap <buffer> <F6> <Plug>(JavaComplete-Imports-AddMissing)`
 
-`imap <F6> <Plug>(JavaComplete-Imports-AddMissing)`
+`imap <buffer> <F6> <Plug>(JavaComplete-Imports-AddMissing)`
 
 To remove all unused imports with F7:
 
-`nmap <F7> <Plug>(JavaComplete-Imports-RemoveUnused)`
+`nmap <buffer> <F7> <Plug>(JavaComplete-Imports-RemoveUnused)`
 
-`imap <F7> <Plug>(JavaComplete-Imports-RemoveUnused)`
+`imap <buffer> <F7> <Plug>(JavaComplete-Imports-RemoveUnused)`
 
 Default mappings:
 
 ```
-  nmap <leader>jI <Plug>(JavaComplete-Imports-AddMissing)
-  nmap <leader>jR <Plug>(JavaComplete-Imports-RemoveUnused)
-  nmap <leader>ji <Plug>(JavaComplete-Imports-AddSmart)
-  nmap <leader>jii <Plug>(JavaComplete-Imports-Add)
+  nmap <buffer> <leader>jI <Plug>(JavaComplete-Imports-AddMissing)
+  nmap <buffer> <leader>jR <Plug>(JavaComplete-Imports-RemoveUnused)
+  nmap <buffer> <leader>ji <Plug>(JavaComplete-Imports-AddSmart)
+  nmap <buffer> <leader>jii <Plug>(JavaComplete-Imports-Add)
 
-  imap <C-j>I <Plug>(JavaComplete-Imports-AddMissing)
-  imap <C-j>R <Plug>(JavaComplete-Imports-RemoveUnused)
-  imap <C-j>i <Plug>(JavaComplete-Imports-AddSmart)
-  imap <C-j>ii <Plug>(JavaComplete-Imports-Add)
+  imap <buffer> <C-j>I <Plug>(JavaComplete-Imports-AddMissing)
+  imap <buffer> <C-j>R <Plug>(JavaComplete-Imports-RemoveUnused)
+  imap <buffer> <C-j>i <Plug>(JavaComplete-Imports-AddSmart)
+  imap <buffer> <C-j>ii <Plug>(JavaComplete-Imports-Add)
 
-  nmap <leader>jM <Plug>(JavaComplete-Generate-AbstractMethods)
+  nmap <buffer> <leader>jM <Plug>(JavaComplete-Generate-AbstractMethods)
 
-  imap <C-j>jM <Plug>(JavaComplete-Generate-AbstractMethods)
+  imap <buffer> <C-j>jM <Plug>(JavaComplete-Generate-AbstractMethods)
 
-  nmap <leader>jA <Plug>(JavaComplete-Generate-Accessors)
-  nmap <leader>js <Plug>(JavaComplete-Generate-AccessorSetter)
-  nmap <leader>jg <Plug>(JavaComplete-Generate-AccessorGetter)
-  nmap <leader>ja <Plug>(JavaComplete-Generate-AccessorSetterGetter)
-  nmap <leader>jts <Plug>(JavaComplete-Generate-ToString)
-  nmap <leader>jeq <Plug>(JavaComplete-Generate-EqualsAndHashCode)
-  nmap <leader>jc <Plug>(JavaComplete-Generate-Constructor)
-  nmap <leader>jcc <Plug>(JavaComplete-Generate-DefaultConstructor)
+  nmap <buffer> <leader>jA <Plug>(JavaComplete-Generate-Accessors)
+  nmap <buffer> <leader>js <Plug>(JavaComplete-Generate-AccessorSetter)
+  nmap <buffer> <leader>jg <Plug>(JavaComplete-Generate-AccessorGetter)
+  nmap <buffer> <leader>ja <Plug>(JavaComplete-Generate-AccessorSetterGetter)
+  nmap <buffer> <leader>jts <Plug>(JavaComplete-Generate-ToString)
+  nmap <buffer> <leader>jeq <Plug>(JavaComplete-Generate-EqualsAndHashCode)
+  nmap <buffer> <leader>jc <Plug>(JavaComplete-Generate-Constructor)
+  nmap <buffer> <leader>jcc <Plug>(JavaComplete-Generate-DefaultConstructor)
 
-  imap <C-j>s <Plug>(JavaComplete-Generate-AccessorSetter)
-  imap <C-j>g <Plug>(JavaComplete-Generate-AccessorGetter)
-  imap <C-j>a <Plug>(JavaComplete-Generate-AccessorSetterGetter)
+  imap <buffer> <C-j>s <Plug>(JavaComplete-Generate-AccessorSetter)
+  imap <buffer> <C-j>g <Plug>(JavaComplete-Generate-AccessorGetter)
+  imap <buffer> <C-j>a <Plug>(JavaComplete-Generate-AccessorSetterGetter)
 
-  vmap <leader>js <Plug>(JavaComplete-Generate-AccessorSetter)
-  vmap <leader>jg <Plug>(JavaComplete-Generate-AccessorGetter)
-  vmap <leader>ja <Plug>(JavaComplete-Generate-AccessorSetterGetter)
+  vmap <buffer> <leader>js <Plug>(JavaComplete-Generate-AccessorSetter)
+  vmap <buffer> <leader>jg <Plug>(JavaComplete-Generate-AccessorGetter)
+  vmap <buffer> <leader>ja <Plug>(JavaComplete-Generate-AccessorSetterGetter)
 
   nmap <silent> <buffer> <leader>jn <Plug>(JavaComplete-Generate-NewClass)
   nmap <silent> <buffer> <leader>jN <Plug>(JavaComplete-Generate-ClassInFile)

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Updated version of the original [javacomplete plugin](http://www.vim.org/scripts
 
 ## Demo
 
-![vim-javacomplete2](https://github.com/artur-shaik/vim-javacomplete2/raw/master/doc/demo.gif)
+![vim-javacomplete2](https://github.com/wsdjeg/vim-javacomplete2/raw/master/doc/demo.gif)
 
 Generics demo
 
-![vim-javacomplete2](https://github.com/artur-shaik/vim-javacomplete2/raw/master/doc/generics_demo.gif)
+![vim-javacomplete2](https://github.com/wsdjeg/vim-javacomplete2/raw/master/doc/generics_demo.gif)
 
 ## Intro
 
@@ -67,27 +67,27 @@ Run:
 
 ````Shell
 cd ~/.vim/bundle
-git clone https://github.com/artur-shaik/vim-javacomplete2.git
+git clone https://github.com/wsdjeg/vim-javacomplete2.git
 ````
 
 ### Vundle
 Add to `.vimrc`:
 
 ````vimL
-Plugin 'artur-shaik/vim-javacomplete2'
+Plugin 'wsdjeg/vim-javacomplete2'
 ````
 
 ### NeoBundle
 Add to `.vimrc`:
 
 ````vimL
-NeoBundle 'artur-shaik/vim-javacomplete2'
+NeoBundle 'wsdjeg/vim-javacomplete2'
 ````
 
 ### vim-plug
 Add to `.vimrc`:
 ````vimL
-Plug 'artur-shaik/vim-javacomplete2'
+Plug 'wsdjeg/vim-javacomplete2'
 ````
 
 ## Configuration

--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -457,7 +457,8 @@ let g:JavaComplete_SourcesPath = get(g:, 'JavaComplete_SourcesPath', ''). g:PATH
 "   let g:JavaComplete_MavenRepositoryDisabled = 1
 " <
 " by default this option is disabled (0).
-let g:JavaComplete_MavenRepositoryDisabled = 0
+let g:JavaComplete_MavenRepositoryDisabled =
+      \ get(g:, 'JavaComplete_MavenRepositoryDisabled', 0)
 
 if filereadable(getcwd(). g:FILE_SEP. 'build.gradle')
     let g:JavaComplete_SourcesPath = g:JavaComplete_SourcesPath

--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -412,9 +412,9 @@ function! s:DefaultMappings() abort
   imap <silent> <buffer> <C-j>g <Plug>(JavaComplete-Generate-AccessorGetter)
   imap <silent> <buffer> <C-j>a <Plug>(JavaComplete-Generate-AccessorSetterGetter)
 
-  vmap <silent> <buffer> <leader>js <Plug>(JavaComplete-Generate-AccessorSetter)
-  vmap <silent> <buffer> <leader>jg <Plug>(JavaComplete-Generate-AccessorGetter)
-  vmap <silent> <buffer> <leader>ja <Plug>(JavaComplete-Generate-AccessorSetterGetter)
+  xmap <silent> <buffer> <leader>js <Plug>(JavaComplete-Generate-AccessorSetter)
+  xmap <silent> <buffer> <leader>jg <Plug>(JavaComplete-Generate-AccessorGetter)
+  xmap <silent> <buffer> <leader>ja <Plug>(JavaComplete-Generate-AccessorSetterGetter)
 
   nmap <silent> <buffer> <leader>jn <Plug>(JavaComplete-Generate-NewClass)
   nmap <silent> <buffer> <leader>jN <Plug>(JavaComplete-Generate-ClassInFile)

--- a/autoload/javacomplete.vim
+++ b/autoload/javacomplete.vim
@@ -380,7 +380,7 @@ function! s:RemoveCurrentFromCache() abort
 endfunction
 
 function! s:DefaultMappings() abort
-  if g:JavaComplete_EnableDefaultMappings
+  if !g:JavaComplete_EnableDefaultMappings
     return
   endif
 

--- a/doc/javacomplete.txt
+++ b/doc/javacomplete.txt
@@ -470,9 +470,9 @@ By default this option is disabled (0).
                                         *g:JavaComplete_EnableDefaultMappings*
 Enable or disable default key mappings, by default this option is 1, and
 default mappings are defined. To disable default mappings, set this option to
-1.
+0.
 >
-  let g:JavaComplete_EnableDefaultMappings = 1
+  let g:JavaComplete_EnableDefaultMappings = 0
 <
 
                                                       *g:JavaComplete_PomPath*

--- a/doc/javacomplete.txt
+++ b/doc/javacomplete.txt
@@ -62,81 +62,82 @@ FEATURES                                               *javacomplete-features*
 INSTALL                                                 *javacomplete-install*
 
   1. This assumes you are using `Vundle`.
-Adapt for your plugin manager of choice. Put this into your `.vimrc`.
+  Adapt for your plugin manager of choice. Put this into your `.vimrc`.
 >
   " Java completion plugin.
   Plugin 'artur-shaik/vim-javacomplete2'
 <
   2. Set 'omnifunc' option. e.g.
-
 >
   autocmd Filetype java setlocal omnifunc=javacomplete#Complete
 <
   3. Map keys you prefer:
-For smart (trying to guess import option) insert class import with <F4>:
+  Inside `~/.vim/after/ftplugin/java.vim` (on Linux and MacOS) respectively
+  ``%USERPROFILE%/vimfiles/after/ftplugin/java.vim`` on Microsoft Windows, to
+  enable smart (trying to guess import option) inserting class imports with
+  <F4>, add:
 >
-    nmap <F4> <Plug>(JavaComplete-Imports-AddSmart)
-    imap <F4> <Plug>(JavaComplete-Imports-AddSmart)
+    nmap <buffer> <F4> <Plug>(JavaComplete-Imports-AddSmart)
+    imap <buffer> <F4> <Plug>(JavaComplete-Imports-AddSmart)
 <
-For usual (will ask for import option) insert class import with <F5>:
+  For usual (will ask for import option) insert class import with <F5>:
 >
-    nmap <F5> <Plug>(JavaComplete-Imports-Add)
-    imap <F5> <Plug>(JavaComplete-Imports-Add)
+    nmap <buffer> <F5> <Plug>(JavaComplete-Imports-Add)
+    imap <buffer> <F5> <Plug>(JavaComplete-Imports-Add)
 <
-For add all missing imports with <F6>:
+  For add all missing imports with <F6>:
 >
-    nmap <F6> <Plug>(JavaComplete-Imports-AddMissing)
-    imap <F6> <Plug>(JavaComplete-Imports-AddMissing)
+    nmap <buffer> <F6> <Plug>(JavaComplete-Imports-AddMissing)
+    imap <buffer> <F6> <Plug>(JavaComplete-Imports-AddMissing)
 <
-For remove all missing imports with <F7>:
+  For remove all missing imports with <F7>:
 >
-    nmap <F7> <Plug>(JavaComplete-Imports-RemoveUnused)
-    imap <F7> <Plug>(JavaComplete-Imports-RemoveUnused)
+    nmap <buffer> <F7> <Plug>(JavaComplete-Imports-RemoveUnused)
+    imap <buffer> <F7> <Plug>(JavaComplete-Imports-RemoveUnused)
 <
-For sorting all imports with <F8>:
+  For sorting all imports with <F8>:
 >
-    nmap <F8> <Plug>(JavaComplete-Imports-SortImports)
-    imap <F8> <Plug>(JavaComplete-Imports-SortImports)
+    nmap <buffer> <F8> <Plug>(JavaComplete-Imports-SortImports)
+    imap <buffer> <F8> <Plug>(JavaComplete-Imports-SortImports)
 <
-
-Default mappings:
+  Default mappings:
 >
-    nmap <leader>jI <Plug>(JavaComplete-Imports-AddMissing)
-    nmap <leader>jR <Plug>(JavaComplete-Imports-RemoveUnused)
-    nmap <leader>ji <Plug>(JavaComplete-Imports-AddSmart)
-    nmap <leader>jii <Plug>(JavaComplete-Imports-Add)
-    nmap <Leader>jis <Plug>(JavaComplete-Imports-SortImports)
+    nmap <buffer> <leader>jI <Plug>(JavaComplete-Imports-AddMissing)
+    nmap <buffer> <leader>jR <Plug>(JavaComplete-Imports-RemoveUnused)
+    nmap <buffer> <leader>ji <Plug>(JavaComplete-Imports-AddSmart)
+    nmap <buffer> <leader>jii <Plug>(JavaComplete-Imports-Add)
+    nmap <buffer> <Leader>jis <Plug>(JavaComplete-Imports-SortImports)
 
-    imap <C-j>I <Plug>(JavaComplete-Imports-AddMissing)
-    imap <C-j>R <Plug>(JavaComplete-Imports-RemoveUnused)
-    imap <C-j>i <Plug>(JavaComplete-Imports-AddSmart)
-    imap <C-j>ii <Plug>(JavaComplete-Imports-Add)
+    imap <buffer> <C-j>I <Plug>(JavaComplete-Imports-AddMissing)
+    imap <buffer> <C-j>R <Plug>(JavaComplete-Imports-RemoveUnused)
+    imap <buffer> <C-j>i <Plug>(JavaComplete-Imports-AddSmart)
+    imap <buffer> <C-j>ii <Plug>(JavaComplete-Imports-Add)
 
-    nmap <leader>jM <Plug>(JavaComplete-Generate-AbstractMethods)
+    nmap <buffer> <leader>jM <Plug>(JavaComplete-Generate-AbstractMethods)
 
-    imap <C-j>jM <Plug>(JavaComplete-Generate-AbstractMethods)
+    imap <buffer> <C-j>jM <Plug>(JavaComplete-Generate-AbstractMethods)
 
-    nmap <leader>jA <Plug>(JavaComplete-Generate-Accessors)
-    nmap <leader>js <Plug>(JavaComplete-Generate-AccessorSetter)
-    nmap <leader>jg <Plug>(JavaComplete-Generate-AccessorGetter)
-    nmap <leader>ja <Plug>(JavaComplete-Generate-AccessorSetterGetter)
-    nmap <leader>jts <Plug>(JavaComplete-Generate-ToString)
-    nmap <leader>jeq <Plug>(JavaComplete-Generate-EqualsAndHashCode)
-    nmap <leader>jc <Plug>(JavaComplete-Generate-Constructor)
-    nmap <leader>jcc <Plug>(JavaComplete-Generate-DefaultConstructor)
+    nmap <buffer> <leader>jA <Plug>(JavaComplete-Generate-Accessors)
+    nmap <buffer> <leader>js <Plug>(JavaComplete-Generate-AccessorSetter)
+    nmap <buffer> <leader>jg <Plug>(JavaComplete-Generate-AccessorGetter)
+    nmap <buffer> <leader>ja <Plug>(JavaComplete-Generate-AccessorSetterGetter)
+    nmap <buffer> <leader>jts <Plug>(JavaComplete-Generate-ToString)
+    nmap <buffer> <leader>jeq <Plug>(JavaComplete-Generate-EqualsAndHashCode)
+    nmap <buffer> <leader>jc <Plug>(JavaComplete-Generate-Constructor)
+    nmap <buffer> <leader>jcc <Plug>(JavaComplete-Generate-DefaultConstructor)
 
-    imap <C-j>s <Plug>(JavaComplete-Generate-AccessorSetter)
-    imap <C-j>g <Plug>(JavaComplete-Generate-AccessorGetter)
-    imap <C-j>a <Plug>(JavaComplete-Generate-AccessorSetterGetter)
+    imap <buffer> <C-j>s <Plug>(JavaComplete-Generate-AccessorSetter)
+    imap <buffer> <C-j>g <Plug>(JavaComplete-Generate-AccessorGetter)
+    imap <buffer> <C-j>a <Plug>(JavaComplete-Generate-AccessorSetterGetter)
 
-    xmap <leader>js <Plug>(JavaComplete-Generate-AccessorSetter)
-    xmap <leader>jg <Plug>(JavaComplete-Generate-AccessorGetter)
-    xmap <leader>ja <Plug>(JavaComplete-Generate-AccessorSetterGetter)
+    xmap <buffer> <leader>js <Plug>(JavaComplete-Generate-AccessorSetter)
+    xmap <buffer> <leader>jg <Plug>(JavaComplete-Generate-AccessorGetter)
+    xmap <buffer> <leader>ja <Plug>(JavaComplete-Generate-AccessorSetterGetter)
 <
 
-  4. Javavi library will be automatcally compiled when you
-use first time.  If no libs/javavi/target is generated, check that you have
-the write permission and jdk installed.
+  4. Javavi library will be automatcally compiled when you use first time.  If
+     no libs/javavi/target is generated, check that you have the write
+     permission and jdk installed.
 
 ==============================================================================
 REQUIREMENTS                                       *javacomplete-requirements*

--- a/doc/javacomplete.txt
+++ b/doc/javacomplete.txt
@@ -30,7 +30,7 @@ javaparser library and javacomplete.txt.
 DOWNLOAD                                               *javacomplete-download*
 
 You can download the lastest version from this url:
-https://github.com/artur-shaik/vim-javacomplete2
+https://github.com/wsdjeg/vim-javacomplete2
 
 ==============================================================================
 FEATURES                                               *javacomplete-features*
@@ -61,11 +61,11 @@ FEATURES                                               *javacomplete-features*
 ==============================================================================
 INSTALL                                                 *javacomplete-install*
 
-  1. This assumes you are using `Vundle`.
+  1. This assumes you are using `Vim-Plug`.
   Adapt for your plugin manager of choice. Put this into your `.vimrc`.
 >
   " Java completion plugin.
-  Plugin 'artur-shaik/vim-javacomplete2'
+  Plug 'wsdjeg/vim-javacomplete2'
 <
   2. Set 'omnifunc' option. e.g.
 >

--- a/doc/javacomplete.txt
+++ b/doc/javacomplete.txt
@@ -129,9 +129,9 @@ Default mappings:
     imap <C-j>g <Plug>(JavaComplete-Generate-AccessorGetter)
     imap <C-j>a <Plug>(JavaComplete-Generate-AccessorSetterGetter)
 
-    vmap <leader>js <Plug>(JavaComplete-Generate-AccessorSetter)
-    vmap <leader>jg <Plug>(JavaComplete-Generate-AccessorGetter)
-    vmap <leader>ja <Plug>(JavaComplete-Generate-AccessorSetterGetter)
+    xmap <leader>js <Plug>(JavaComplete-Generate-AccessorSetter)
+    xmap <leader>jg <Plug>(JavaComplete-Generate-AccessorGetter)
+    xmap <leader>ja <Plug>(JavaComplete-Generate-AccessorSetterGetter)
 <
 
   4. Javavi library will be automatcally compiled when you

--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -465,14 +465,16 @@ let g:JavaComplete_InsertImports =
       \ get(g:, 'JavaComplete_InsertImports', 1)
 ""
 " Set the path of gradle executable file. by default it is empty string.
-let g:JavaComplete_GradleExecutable = ''
+let g:JavaComplete_GradleExecutable =
+      \ get(g:, 'JavaComplete_GradleExecutable', '')
 ""
 " The Java daemon should kill itself when Vim stops.
 " Also its possible to configure the timeout,
 " so if there is no request during this time the daemon will stop.
 " To configure the timemout use the following (in seconds).
 " By default this option is 0.
-let g:JavaComplete_ServerAutoShutdownTime = 0
+let g:JavaComplete_ServerAutoShutdownTime =
+      \ get(g:, 'JavaComplete_ServerAutoShutdownTime', 0)
 let g:JavaComplete_ShowExternalCommandsOutput =
       \ get(g:, 'JavaComplete_ShowExternalCommandsOutput', 0)
 
@@ -543,7 +545,8 @@ let g:JavaComplete_EnableDefaultMappings =
 "   let g:JavaComplete_PomPath = /path/to/pom.xml
 " <
 " It will be set automatically, if pom.xml is in underlying path.
-let g:JavaComplete_PomPath = ''
+let g:JavaComplete_PomPath =
+      \ get(g:, 'JavaComplete_PomPath', '')
 ""
 " Close brace on method declaration completion:
 " >
@@ -552,12 +555,14 @@ let g:JavaComplete_PomPath = ''
 " Add close brace automatically, when complete method declaration.
 " By default this option is enabled (1).
 " Disable if it conflicts with another plugins.
-let g:JavaComplete_ClosingBrace = 1
+let g:JavaComplete_ClosingBrace =
+      \ get(g:, 'JavaComplete_ClosingBrace', 1)
 
 ""
 " Set the directory where to write server logs. By default this option is
 " empty.
-let g:JavaComplete_JavaviLogDirectory = ''
+let g:JavaComplete_JavaviLogDirectory =
+      \ get(g:, 'JavaComplete_JavaviLogDirectory', '')
 let g:JavaComplete_CompletionResultSort =
       \ get(g:, 'JavaComplete_CompletionResultSort', 0)
 ""
@@ -567,7 +572,8 @@ let g:JavaComplete_CompletionResultSort =
 "   let g:JavaComplete_CustomTemplateDirectory = '~/jc_templates'
 " <
 " By default this options is empty string.
-let g:JavaComplete_CustomTemplateDirectory = ''
+let g:JavaComplete_CustomTemplateDirectory =
+      \ get(g:, 'JavaComplete_CustomTemplateDirectory', '')
 
 ""
 " @section Commands, commands

--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -533,9 +533,10 @@ let g:JavaComplete_UseFQN = get(g:, 'JavaComplete_UseFQN', 0)
 " by default this option is 1, and default mappings are defined.
 " To disable default mappings, set this option to 1.
 " >
-"   let g:JavaComplete_EnableDefaultMappings = 1
+"   let g:JavaComplete_EnableDefaultMappings = 0
 " <
-let g:JavaComplete_EnableDefaultMappings = 0
+let g:JavaComplete_EnableDefaultMappings =
+      \ get(g:, 'JavaComplete_EnableDefaultMappings', 1)
 ""
 " Set pom.xml path explicitly:
 " >

--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -118,9 +118,9 @@
 "     imap <C-j>g <Plug>(JavaComplete-Generate-AccessorGetter)
 "     imap <C-j>a <Plug>(JavaComplete-Generate-AccessorSetterGetter)
 " 
-"     vmap <leader>js <Plug>(JavaComplete-Generate-AccessorSetter)
-"     vmap <leader>jg <Plug>(JavaComplete-Generate-AccessorGetter)
-"     vmap <leader>ja <Plug>(JavaComplete-Generate-AccessorSetterGetter)
+"     xmap <leader>js <Plug>(JavaComplete-Generate-AccessorSetter)
+"     xmap <leader>jg <Plug>(JavaComplete-Generate-AccessorGetter)
+"     xmap <leader>ja <Plug>(JavaComplete-Generate-AccessorSetterGetter)
 " <
 " 
 " 4. Javavi library will be automatcally compiled when you

--- a/plugin/javacomplete.vim
+++ b/plugin/javacomplete.vim
@@ -46,7 +46,7 @@
 " @section Download, download
 " @parentsection overview
 " You can download the lastest version from this url:
-	" https://github.com/artur-shaik/vim-javacomplete2
+	" https://github.com/wsdjeg/vim-javacomplete2
 
 ""
 " @section Install, install
@@ -55,7 +55,7 @@
 " Adapt for your plugin manager of choice. Put this into your `.vimrc`.
 " >
 "   " Java completion plugin.
-"   Plugin 'artur-shaik/vim-javacomplete2'
+"   Plugin 'wsdjeg/vim-javacomplete2'
 " <
 " 2. Set 'omnifunc' option. e.g.
 " >


### PR DESCRIPTION
Usually there is a setting DisableDefaultMappings. Here it is Enable, but in many places the it disabled the default mappings instead.